### PR TITLE
feat: add context to get approval request

### DIFF
--- a/clients/python/phantasmpy/client.py
+++ b/clients/python/phantasmpy/client.py
@@ -25,12 +25,18 @@ class Phantasm:
         response = self.connection.Heartbeat(request=Empty())
         return HeartbeatResponse(version=response.version)
 
-    def get_approval(self, name: str, parameters: Any) -> GetApprovalResponse:
+    def get_approval(
+        self,
+        name: str,
+        parameters: Any,
+        context: str = "",
+    ) -> GetApprovalResponse:
         """Request approval for an operation from the approver.
 
         Args:
         - name: Name of the operation, typically, the function name.
         - parameters: Parameters used in the operation.
+        - context: Additional information about the operation.
 
         Parameters will be relayed as a JSON string to the approver. The
         approver can choose to modify the parameters with the correct values
@@ -38,8 +44,11 @@ class Phantasm:
         """
 
         try:
-            _params = json.dumps(parameters)
-            request = protos.GetApprovalRequest(name=name, parameters=_params)
+            request = protos.GetApprovalRequest(
+                name=name,
+                parameters=json.dumps(parameters),
+                context=context,
+            )
         except Exception as e:
             raise ValueError(f"Invalid parameters: {e}")
 
@@ -60,7 +69,11 @@ def emulate_get_approval():
     }
 
     phantasm = Phantasm()
-    response = phantasm.get_approval(name="multiply", parameters=params)
+    response = phantasm.get_approval(
+        name="multiply",
+        parameters=params,
+        context="Multiply two numbers: x and y.",
+    )
 
     if response.approved:
         # Here, we're going to trust our approver and unpack the parameters.

--- a/clients/python/stubs/receiver_pb2.py
+++ b/clients/python/stubs/receiver_pb2.py
@@ -22,7 +22,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0ereceiver.proto\x12\x08receiver\x1a\x1bgoogle/protobuf/empty.proto"$\n\x11HeartbeatResponse\x12\x0f\n\x07version\x18\x01 \x01(\t"6\n\x12GetApprovalRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x12\n\nparameters\x18\x02 \x01(\t";\n\x13GetApprovalResponse\x12\x10\n\x08\x61pproved\x18\x01 \x01(\x08\x12\x12\n\nparameters\x18\x02 \x01(\t2\x9c\x01\n\x08Receiver\x12\x42\n\tHeartbeat\x12\x16.google.protobuf.Empty\x1a\x1b.receiver.HeartbeatResponse"\x00\x12L\n\x0bGetApproval\x12\x1c.receiver.GetApprovalRequest\x1a\x1d.receiver.GetApprovalResponse"\x00\x62\x06proto3'
+    b'\n\x0ereceiver.proto\x12\x08receiver\x1a\x1bgoogle/protobuf/empty.proto"$\n\x11HeartbeatResponse\x12\x0f\n\x07version\x18\x01 \x01(\t"G\n\x12GetApprovalRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x12\n\nparameters\x18\x02 \x01(\t\x12\x0f\n\x07\x63ontext\x18\x03 \x01(\t";\n\x13GetApprovalResponse\x12\x10\n\x08\x61pproved\x18\x01 \x01(\x08\x12\x12\n\nparameters\x18\x02 \x01(\t2\x9c\x01\n\x08Receiver\x12\x42\n\tHeartbeat\x12\x16.google.protobuf.Empty\x1a\x1b.receiver.HeartbeatResponse"\x00\x12L\n\x0bGetApproval\x12\x1c.receiver.GetApprovalRequest\x1a\x1d.receiver.GetApprovalResponse"\x00\x62\x06proto3'
 )
 
 _globals = globals()
@@ -33,9 +33,9 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_HEARTBEATRESPONSE"]._serialized_start = 57
     _globals["_HEARTBEATRESPONSE"]._serialized_end = 93
     _globals["_GETAPPROVALREQUEST"]._serialized_start = 95
-    _globals["_GETAPPROVALREQUEST"]._serialized_end = 149
-    _globals["_GETAPPROVALRESPONSE"]._serialized_start = 151
-    _globals["_GETAPPROVALRESPONSE"]._serialized_end = 210
-    _globals["_RECEIVER"]._serialized_start = 213
-    _globals["_RECEIVER"]._serialized_end = 369
+    _globals["_GETAPPROVALREQUEST"]._serialized_end = 166
+    _globals["_GETAPPROVALRESPONSE"]._serialized_start = 168
+    _globals["_GETAPPROVALRESPONSE"]._serialized_end = 227
+    _globals["_RECEIVER"]._serialized_start = 230
+    _globals["_RECEIVER"]._serialized_end = 386
 # @@protoc_insertion_point(module_scope)

--- a/dashboard/src/lib/components/cards/approval.svelte
+++ b/dashboard/src/lib/components/cards/approval.svelte
@@ -5,7 +5,15 @@
   import { EditorState } from "@codemirror/state"
   import { defaultKeymap, indentWithTab } from "@codemirror/commands"
   import { javascript } from "@codemirror/lang-javascript"
-  import { Checkmark, CloseLarge, PartitionSame } from "carbon-icons-svelte"
+  import Tooltip from "../utils/tooltip.svelte"
+
+  // Icons.
+  import {
+    Checkmark,
+    CloseLarge,
+    PartitionSame,
+    Information
+  } from "carbon-icons-svelte"
 
   const iconSize = 16
 
@@ -14,6 +22,7 @@
 
   let editor: Element
   let ws: WebSocket = getContext("ws")
+  let showTooltip: boolean = false
   let showParameters: boolean = false
   let error = false
 
@@ -71,7 +80,7 @@
     remove()
   }
 
-  function deny() {
+  function reject() {
     let response: ApprovalResponse = {
       id: request.id,
       approved: false,
@@ -86,13 +95,25 @@
 <small class="text-xs text-gray-300">{request.id}</small>
 
 <div class="group card space-x-4">
-  <div class="w-full font-mono font-bold truncate">{request.name}</div>
+  <div class="w-full flex items-center space-x-1">
+    <button
+      class="text-gray-400"
+      on:click={() => {
+        showTooltip = !showTooltip
+      }}
+    >
+      <Information size={iconSize} />
+    </button>
+    <p class="font-mono font-bold truncate">
+      {request.name}
+    </p>
+  </div>
   <div class="flex flex-none space-x-1">
     <button class="card-button green space-x-1" on:click={approve}>
       <Checkmark size={iconSize} />
       <span>Approve</span>
     </button>
-    <button class="card-button red" on:click={deny}>
+    <button class="card-button red" on:click={reject}>
       <CloseLarge size={iconSize} />
     </button>
     <button
@@ -104,6 +125,15 @@
       <PartitionSame size={iconSize} />
     </button>
   </div>
+
+  <!-- This tooltip is triggered by the info icon button. -->
+  <Tooltip
+    show={showTooltip}
+    content={request.context}
+    close={() => {
+      showTooltip = false
+    }}
+  />
 </div>
 
 <div class="card-editor-container space-y-1 {showParameters ? 'show' : 'hide'}">
@@ -117,7 +147,7 @@
 
 <style lang="postcss">
   .card {
-    @apply flex flex-row items-center p-4 rounded;
+    @apply flex flex-row relative items-center p-4 rounded;
     @apply border bg-gray-50 border-gray-200;
   }
 

--- a/dashboard/src/lib/components/cards/approval.svelte
+++ b/dashboard/src/lib/components/cards/approval.svelte
@@ -95,15 +95,17 @@
 <small class="text-xs text-gray-300">{request.id}</small>
 
 <div class="group card space-x-4">
-  <div class="w-full flex items-center space-x-1">
-    <button
-      class="text-gray-400"
-      on:click={() => {
-        showTooltip = !showTooltip
-      }}
-    >
-      <Information size={iconSize} />
-    </button>
+  <div class="w-full flex items-center space-x-2">
+    {#if request.context}
+      <button
+        class="text-gray-400"
+        on:click={() => {
+          showTooltip = !showTooltip
+        }}
+      >
+        <Information size={iconSize} />
+      </button>
+    {/if}
     <p class="font-mono font-bold truncate">
       {request.name}
     </p>

--- a/dashboard/src/lib/components/utils/tooltip.svelte
+++ b/dashboard/src/lib/components/utils/tooltip.svelte
@@ -18,15 +18,20 @@
 
 {#if show && content}
   <div class="tooltip" use:clickoutside={close}>
-    <p class="text-xs text-gray-500 whitespace-pre-line">
+    <div class="tooltip-content">
       {content}
-    </p>
+    </div>
   </div>
 {/if}
 
 <style lang="postcss">
   .tooltip {
     @apply absolute bottom-[48px] left-0;
-    @apply max-w-96 p-4 rounded shadow bg-white;
+    @apply rounded shadow bg-white;
+  }
+
+  .tooltip-content {
+    @apply text-xs text-gray-500 whitespace-pre-line;
+    @apply max-w-96 max-h-48 p-4 overflow-y-auto;
   }
 </style>

--- a/dashboard/src/lib/components/utils/tooltip.svelte
+++ b/dashboard/src/lib/components/utils/tooltip.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  export let content: string
+  export let show: boolean = false
+  export let close: () => void
+
+  function clickoutside(node: HTMLElement, callback: () => void) {
+    const click = (event: MouseEvent) => {
+      if (!node.contains(event.target as Node)) {
+        callback()
+      }
+    }
+
+    document.addEventListener("click", click, true)
+    const destroy = () => document.removeEventListener("click", click, true)
+    return { destroy }
+  }
+</script>
+
+{#if show && content}
+  <div class="tooltip" use:clickoutside={close}>
+    <p class="text-xs text-gray-500 whitespace-pre-line">
+      {content}
+    </p>
+  </div>
+{/if}
+
+<style lang="postcss">
+  .tooltip {
+    @apply absolute bottom-[48px] left-0;
+    @apply max-w-96 p-4 rounded shadow bg-white;
+  }
+</style>

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -14,6 +14,7 @@ export type ApprovalRequest = {
   id: string
   name: string
   parameters: string
+  context: string
 }
 
 export type ApprovalResponse = {

--- a/protos/receiver.proto
+++ b/protos/receiver.proto
@@ -30,6 +30,7 @@ message HeartbeatResponse {
 message GetApprovalRequest {
     string name = 1;
     string parameters = 2;
+    string context = 3;
 }
 
 message GetApprovalResponse {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use crate::protos;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use tokio::sync::mpsc::UnboundedSender;
@@ -51,6 +52,18 @@ pub struct ApprovalRequest {
     pub id: ApprovalID,
     pub name: String,
     pub parameters: String,
+    pub context: String,
+}
+
+impl From<protos::GetApprovalRequest> for ApprovalRequest {
+    fn from(value: protos::GetApprovalRequest) -> Self {
+        Self {
+            id: ApprovalID::new(),
+            name: value.name,
+            parameters: value.parameters,
+            context: value.context,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,4 +71,12 @@ pub struct ApprovalResponse {
     pub id: ApprovalID,
     pub approved: bool,
     pub parameters: String,
+}
+
+impl From<ApprovalResponse> for protos::GetApprovalResponse {
+    fn from(value: ApprovalResponse) -> Self {
+        let approved = value.approved;
+        let parameters = value.parameters;
+        Self { approved, parameters }
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,13 +55,26 @@ pub struct ApprovalRequest {
     pub context: String,
 }
 
+impl ApprovalRequest {
+    pub fn sanitize_context(context: impl Into<String>) -> String {
+        let context: String = context.into();
+        if context.is_empty() {
+            return context;
+        }
+
+        let context = context.trim();
+        let lines: Vec<&str> = context.lines().map(str::trim).collect();
+        lines.join("\n")
+    }
+}
+
 impl From<protos::GetApprovalRequest> for ApprovalRequest {
     fn from(value: protos::GetApprovalRequest) -> Self {
         Self {
             id: ApprovalID::new(),
             name: value.name,
             parameters: value.parameters,
-            context: value.context,
+            context: Self::sanitize_context(value.context),
         }
     }
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is addressed. -->

Fixes #1

This PR allows clients to pass `context` string to the server which then will be relayed to the dashboard. This allows approvers to have a better context about the pending operation. This could be used to pass comments about the function or LLM prompts triggering the function, etc.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce and test them. -->

I'm not quite sure how to add a unit test to include this change.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
