### PR TITLE
feat: add client to receiver authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PHANTASM_SECRET=xxx


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is addressed. -->

Fixes #3 

This PR adds an interceptor to the receiver server service to check for the secret key, `PHANTASM_SECRET`, set as the server environment variable. If the secret environment variable is not set, no authentication is required from the client to execute a method.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce and test them. -->

- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my changes are working as expected.

To test:

1. Create a .env file with `PHANTASM_SECRET` set to a value.
2. Run the server.
3. Use the Python client to emulate calling the get approval method.
4. Add the secret as a parameter when instantiating the Phantasm class in Python client.
5. If not set to the value, it will return an unauthenticated error to the client.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.