### PR TITLE
feat: response from dashboard include approvers detail

### DIFF
--- a/dashboard/src/lib/components/cards/approval.svelte
+++ b/dashboard/src/lib/components/cards/approval.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, getContext } from "svelte"
-  import type { ApprovalRequest, ApprovalResponse } from "$lib/types"
+  import { approver } from "$lib/store"
+  import type { ApprovalRequest, ApprovalResponse, Approver } from "$lib/types"
   import { EditorView, keymap, highlightActiveLine } from "@codemirror/view"
   import { EditorState } from "@codemirror/state"
   import { defaultKeymap, indentWithTab } from "@codemirror/commands"
@@ -73,7 +74,8 @@
     let response: ApprovalResponse = {
       id: request.id,
       approved: true,
-      parameters: params
+      parameters: params,
+      approver: $approver as Approver
     }
 
     ws.send(JSON.stringify(response))
@@ -84,7 +86,8 @@
     let response: ApprovalResponse = {
       id: request.id,
       approved: false,
-      parameters: ""
+      parameters: "",
+      approver: $approver as Approver
     }
 
     ws.send(JSON.stringify(response))

--- a/dashboard/src/lib/store.ts
+++ b/dashboard/src/lib/store.ts
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store"
-import type { Connection, Alert } from "./types.ts"
+import type { Connection, Alert, Approver } from "./types.ts"
 
+export const approver = writable<Approver | undefined>(undefined)
 export const connections = writable<Connection[]>([])
 export const alerts = writable<Alert[]>([])

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -21,4 +21,10 @@ export type ApprovalResponse = {
   id: string
   approved: boolean
   parameters: string
+  approver: Approver
+}
+
+export type Approver = {
+  name: string
+  email: string
 }

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -76,7 +76,7 @@
       <div class="flex flex-col space-y-3">
         <h3>Approver Profile</h3>
         <small>
-          This information gives more context to the approval response.
+          This information adds more context to the approval response.
         </small>
       </div>
       <div class="flex flex-col space-y-3">

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { flip } from "svelte/animate"
   import { connections } from "$lib/store"
+  import type { Connection } from "$lib/types"
   import Wordmark from "$lib/components/utils/wordmark.svelte"
   import Title from "$lib/components/utils/title.svelte"
   import ActionButton from "$lib/components/buttons/action.svelte"
@@ -25,19 +26,19 @@
       return
     }
 
-    let new_connection = {
+    let connection: Connection = {
       id: crypto.randomUUID(),
       name: name,
       address: address
     }
 
     connections.update((conn) => {
-      conn.push(new_connection)
+      conn.push(connection)
       return conn
     })
 
     window.localStorage.setItem("connections", JSON.stringify($connections))
-    connect(new_connection.id)
+    connect(connection.id)
   }
 
   function deleteConnection(id: string) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ async fn start_handler(args: &ArgMatches) {
 async fn start_receiver_server(service: Arc<Phantasm>, port: u16) {
     let service = ReceiverServer::with_interceptor(service, auth_interceptor);
     let addr = format!("[::]:{port}").parse().unwrap();
-    tracing::info!("Receiver server is ready on port {port}");
+    tracing::info!("The receiver server is ready on port {port}");
 
     Server::builder()
         .add_service(service)
@@ -113,7 +113,7 @@ async fn start_coordinator_server(service: Arc<Phantasm>, port: u16) {
     let addr = format!("[::]:{port}");
     let listener = TcpListener::bind(addr).await.unwrap();
 
-    tracing::info!("Coordinator server is ready on port {port}");
+    tracing::info!("The coordinator server is ready on port {port}");
 
     while let Ok((stream, _)) = listener.accept().await {
         let peer_addr = stream
@@ -125,7 +125,7 @@ async fn start_coordinator_server(service: Arc<Phantasm>, port: u16) {
             peer_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         }
 
-        tracing::info!("Connection established with {peer_ip}");
+        tracing::info!("A connection is established with {peer_ip}");
 
         let service = service.clone();
         tokio::spawn(async move {
@@ -143,7 +143,7 @@ async fn start_coordinator_server(service: Arc<Phantasm>, port: u16) {
                 }
 
                 service.remove_connection(&connection_id);
-                tracing::info!("Connection closed: {peer_ip}");
+                tracing::info!("A connection is closed: {peer_ip}");
             });
 
             tokio::spawn(async move {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -125,6 +125,10 @@ mod tests {
             id: approval_id,
             approved: true,
             parameters: params.to_string(),
+            approver: Approver {
+                name: "Alice".to_string(),
+                email: "alice@wonderland.com".to_string(),
+            },
         };
 
         let response_string = serde_json::to_string(&response).unwrap();

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -127,7 +127,7 @@ mod tests {
             parameters: params.to_string(),
             approver: Approver {
                 name: "Alice".to_string(),
-                email: "alice@wonderland.com".to_string(),
+                email: "alice@thewonderland.com".to_string(),
             },
         };
 

--- a/src/services/receiver.rs
+++ b/src/services/receiver.rs
@@ -54,12 +54,13 @@ impl Receiver for Arc<Phantasm> {
             Status::internal("Failed to receive approval response")
         })?;
 
+        let approver = &result.approver.name;
         let verdict = match result.approved {
             true => "approved",
             false => "rejected",
         };
 
-        tracing::info!("The request {approval_id} is {verdict}");
+        tracing::info!("The request {approval_id} is {verdict} by {approver}");
         self.reduce_load(&connection_id);
         Ok(Response::new(result.into()))
     }

--- a/src/services/receiver.rs
+++ b/src/services/receiver.rs
@@ -31,7 +31,7 @@ impl Receiver for Arc<Phantasm> {
         let connection = self.get_connection(&connection_id).unwrap();
         let message = ApprovalRequest::from(request.into_inner());
         let approval_id = message.id;
-        tracing::info!("Approval request is created: {approval_id}");
+        tracing::info!("An approval request is created: {approval_id}");
 
         // Create a one-time use WebSocket channel to coordinate the
         // approval response from the approver. The sender is used to send
@@ -55,11 +55,11 @@ impl Receiver for Arc<Phantasm> {
         })?;
 
         let verdict = match result.approved {
-            true => "Approved",
-            false => "Rejected",
+            true => "approved",
+            false => "rejected",
         };
 
-        tracing::info!("Request {approval_id}: {verdict}");
+        tracing::info!("The request {approval_id} is {verdict}");
         self.reduce_load(&connection_id);
         Ok(Response::new(result.into()))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -84,6 +84,7 @@ pub struct ApprovalResponse {
     pub id: ApprovalID,
     pub approved: bool,
     pub parameters: String,
+    pub approver: Approver,
 }
 
 impl From<ApprovalResponse> for protos::GetApprovalResponse {
@@ -92,4 +93,10 @@ impl From<ApprovalResponse> for protos::GetApprovalResponse {
         let parameters = value.parameters;
         Self { approved, parameters }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Approver {
+    pub name: String,
+    pub email: String,
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is addressed. -->

Fixes #19 

This PR adds an approver data type which will be included in a response to the coordinator server when the approvers either approve or reject the request. We also add the approver name in the tracing after the server receives the response from the dashboard.

We also add a prompt for Approver Profile in the dashboard.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce and test them. -->

- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my changes are working as expected.

I have tested it locally by running the server and simulating an approval request.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

This change's scope is within the dashboard and coordinator server functionality.