### PR TITLE
feat(python): create require approval decorator

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -15,23 +15,14 @@ adding an approval workflow to your function:
 
 ```py
 from phantasmpy import Phantasm
+phantasm = Phantasm()
 
-# Replace with your own function and parameters.
-parameters = {...}
+# Replace with your own function.
+@phantasm.require_approval()
 def schedule_meeting(...):
     pass
 
-phantasm = Phantasm()
-response = phantasm.get_approval(
-    name="schedule_meeting",
-    parameters=parameters
-)
-
-if response.approved:
-    # Do this only if you trust the approvers.
-    schedule_meeting(**response.parameters)
-else:
-    fallback()
+schedule_meeting(...)
 ```
 
 ## Advanced Usage With LangChain

--- a/clients/python/phantasmpy/client.py
+++ b/clients/python/phantasmpy/client.py
@@ -1,6 +1,7 @@
 import grpc
 import json
-from typing import Any, Dict
+from typing import Any, Callable
+from functools import wraps
 from google.protobuf.empty_pb2 import Empty
 from .stubs import receiver_pb2 as protos
 from .stubs.receiver_pb2_grpc import ReceiverStub
@@ -72,6 +73,16 @@ class Phantasm:
             approved=response.approved,
             parameters=response.parameters or "",
         )
+
+    def require_approval(self, with_parameters: bool = True):
+        def decorator(function: Callable):
+            @wraps(function)
+            def wrapper(*args, **kwargs):
+                # TODO: Implement the decorator
+                pass
+
+            return wrapper
+        return decorator
 
 
 def test_get_approval():

--- a/clients/python/phantasmpy/client.py
+++ b/clients/python/phantasmpy/client.py
@@ -75,6 +75,28 @@ class Phantasm:
         )
 
     def require_approval(self, with_parameters: bool = True):
+        """Decorator to request approval before executing a function.
+
+        By default, the decorator will use the parameters provided by the
+        approvers to call the function. If you want to use the original
+        parameters, set `with_parameters` to false.
+
+        This decorator raises exceptions if:
+        - The approval request is rejected.
+        - Error when requesting approval from the server.
+
+        Example:
+
+        ```py
+        phantasm = Phantasm()
+        @phantasm.require_approval()
+        def double(x: int) -> int:
+            return x * 2
+
+        double(x=5)
+        ```
+        """
+
         def decorator(function: Callable):
             @wraps(function)
             def wrapper(**kwargs):
@@ -91,7 +113,7 @@ class Phantasm:
                         kwargs = response.parameters
                     return function(**kwargs)
 
-                raise PermissionError("The approval request is rejected.")
+                raise PermissionError("The approval request is not approved.")
 
             return wrapper
 

--- a/clients/python/phantasmpy/client.py
+++ b/clients/python/phantasmpy/client.py
@@ -74,7 +74,7 @@ class Phantasm:
             parameters=response.parameters or "",
         )
 
-    def require_approval(self, with_parameters: bool = True):
+    def require_approval(self, with_parameters: bool = True) -> Callable:
         """Decorator to request approval before executing a function.
 
         By default, the decorator will use the parameters provided by the
@@ -97,9 +97,9 @@ class Phantasm:
         ```
         """
 
-        def decorator(function: Callable):
+        def decorator(function: Callable) -> Callable:
             @wraps(function)
-            def wrapper(**kwargs):
+            def wrapper(**kwargs) -> Callable:
                 name = function.__name__
                 docs = function.__doc__ or ""
                 response = self.get_approval(


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is addressed. -->

Fixes #12 

This adds a `require_approval()` decorator to Phantasm. Instead of having 2 decorators as written in the issue, we only add a decorator with an optional argument `with_parameters` which defaults to true. Users can disable this to ignore approver-modified parameters when calling the function.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce and test them. -->

- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my changes are working as expected.

I have tested this manually by:

1. Running the server and the dashboard.
2. Connecting the dashboard to the coordinator server.
3. Running the updated `test_get_approval` script in the Python client.

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.